### PR TITLE
Add notebooks to resulting quarto site

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,3 @@ The cheminformatics and ML for chemistry have a lively open source community. He
 
 Check them out and don't forget to leave a star on GitHub and follow the authors on Twitter, if you like the content. 
 Those blogs and webpages have all helped me during the creation of this course (and also before, when I was learning about ML for Chemistry).
-
-## Tweets
-
-{{< tweet pschwllr 1629098793399472130 >}}

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -4,7 +4,7 @@ project:
 book:
   title: "EPFL CH-457"
   author: "Philippe Schwaller"
-  date: "26/5/2023"
+  date: "2024-03-03"
   page-navigation: true
   chapters:
     - index.qmd
@@ -76,5 +76,3 @@ format:
   html:
     theme: cosmo
     number-depth: 0
-  pdf:
-    documentclass: scrreprt

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -5,8 +5,68 @@ book:
   title: "EPFL CH-457"
   author: "Philippe Schwaller"
   date: "26/5/2023"
+  page-navigation: true
   chapters:
     - index.qmd
+    - part: Python Essentials
+      chapters:
+        - text: Crash Course
+          href: notebooks/01 - Basics/01a_python_crash_course.ipynb
+        - text: Pandas
+          href: notebooks/01 - Basics/01b_python_essentials_pandas.ipynb 
+        - text: Plotting
+          href: notebooks/01 - Basics/01c_python_essentials_plotting.ipynb
+        - text: RDKit Basics
+          href: notebooks/01 - Basics/01d_rdkit_basics.ipynb
+    - part: Supervised Learning
+      chapters:
+        - text: Introduction to Supervised Learning
+          href: notebooks/02 - Supervised Learning/training_and_evaluating_ml_models.ipynb
+    - part: Deep Learning
+      chapters:
+        - text: Introduction to Deep Learning
+          href: notebooks/03 - Intro to Deep Learning/01_intro_to_dl.ipynb
+        - text: Graph Neural Networks
+          href: notebooks/03 - Intro to Deep Learning/02_graph_nns.ipynb
+        - text: Simple Example with GNNs
+          href: notebooks/03 - Intro to Deep Learning/03_gnn_simple_example.ipynb
+    - part: Unsupervised Learning
+      chapters:
+        - text: Clustering
+          href: notebooks/04 - Unsupervised Learning/Clustering.ipynb 
+        - text: Dimensionality Reduction
+          href: notebooks/04 - Unsupervised Learning/DimensionalityReduction.ipynb
+        - text: Palladium Catalyst Discovery
+          href: notebooks/04 - Unsupervised Learning/palladium_dimers_discovery.ipynb
+    - part: Generative Models
+      chapters:
+        - text: Molecular Generative Models
+          href: notebooks/05 - Generative Models/Molecular Generative Models.ipynb
+        - text: Generative SMILES Models
+          href: notebooks/06 - Generative Models 2/SMILES-LSTM-Walkthrough.ipynb
+    - part: Reaction Prediction
+      chapters:
+      - text: Molecular Transformers
+        href: notebooks/07 - Reaction Prediction/template_free.ipynb
+    - part: Retrosynthesis
+      chapters:
+        - text: Retrosynthetic Prediction
+          href: notebooks/08 - Retrosynthesis/template_based.ipynb
+    - part: Reaction Properties
+      chapters:
+        - text: Atom Mapping
+          href: notebooks/09 - Reaction properties/01_atom_mapping.ipynb
+        - text: Yield Prediction
+          href: notebooks/09 - Reaction properties/02_yield_prediction.ipynb
+    - part: Bayesian Optimization
+      chapters:
+        - text: Buchwald-Hartwig Optimization
+          href: notebooks/10 - Bayesian optimization/Buchwald-Hartwig-BO.ipynb
+    - part: Model Deployment
+      chapters:
+        - text: Streamlit Tutorial
+          href: notebooks/11 - Model deployment/streamlit_tutorial.ipynb
+        - notebooks/11 - Model deployment/streamlit_tutorial.ipynb
     - references.qmd
 
 bibliography: references.bib
@@ -15,8 +75,6 @@ csl: nature.csl
 format:
   html:
     theme: cosmo
+    number-depth: 0
   pdf:
     documentclass: scrreprt
-
-
-

--- a/notebooks/02 - Supervised Learning/training_and_evaluating_ml_models.ipynb
+++ b/notebooks/02 - Supervised Learning/training_and_evaluating_ml_models.ipynb
@@ -33,18 +33,24 @@
     "# 0. Relevant packages\n",
     "\n",
     "### Scikit-learn\n",
+    "\n",
     "Scikit-learn is an open source machine learning library that supports supervised and unsupervised learning. It also provides various tools for model fitting, data preprocessing, model selection, model evaluation, and many other utilities. We will learn to use scikit-learn to do machine learning work. You can also browse the scikit-learn [user guide](https://scikit-learn.org/stable/user_guide.html) and [tutorials](https://scikit-learn.org/stable/tutorial/index.html) for additional details.\n",
+    "\n",
     "### Essential Libraries and Tools \n",
+    "\n",
     "Scikit-learn depends on two other Python packages, NumPy and SciPy. For plotting and interactive development, you should also install matplotlib, IPython, and the Jupyter Notebook.\n",
+    "\n",
     "- **NumPy** is one of the fundamental packages for scientific computing in Python. In scikit-learn, the NumPy array is the fundamental data structure. Any data you’re using will have to be converted to a NumPy array.\n",
     "- **SciPy** is a collection of functions for scientific computing in Python. Scikit-learn draws from SciPy’s collection of functions for implementing its algorithms.\n",
     "- **Matplotlib** is the primary scientific plotting library in Python. It provides functions for making publication-quality visualizations such as line charts, histograms, scatter plots, and so on.\n",
     "- **Pandas** Python library for data wrangling and analysis. It can ingest from a great variety of file formats and databases, like SQL, Excel files, and comma-separated values (CSV) files.\n",
     "\n",
     "### XGBoost\n",
+    "\n",
     "XGBoost (eXtreme Gradient Boosting) is an optimized distributed gradient boosting library designed to be highly efficient, flexible and portable. It implements machine learning algorithms under the Gradient Boosting framework. XGBoost provides a parallel tree boosting (also known as GBDT, GBM) that solve many data science problems in a fast and accurate way. You can also browse the [XGBoost Documentation](https://xgboost.readthedocs.io/en/stable/) for additional details.\n",
     "\n",
     "### DeepChem\n",
+    "\n",
     "DeepChem is a high quality open-source toolchain that democratizes the use of deep-learning in chemistry, biology and materials science. It also provides various tools for dataset loader, splitters, molecular featurization, model construction and hyperparameter tuning. You can also browse the [DeepChem Ducumentation](https://deepchem.readthedocs.io/en/latest/) for additional details."
    ]
   },
@@ -80,11 +86,14 @@
    "metadata": {},
    "source": [
     "# 1. Supervised learning\n",
+    "\n",
     "Two major types of supervised machine learning problems:\n",
+    "\n",
     "- **Classification**, where the task task is to predict a class label (e.g. what color, what smell, state of aggregation, etc).\n",
     "- **Regression**, where the task is to predict a real number (e.g. solubility in water, yield, selectivity, etc).\n",
     "\n",
     "## 1.1 Algorithms\n",
+    "\n",
     "- k-Nearest Neighbors (k-NN)\n",
     "- Linear Models\n",
     "- Support Vector Machines (SVM)\n",
@@ -919,12 +928,10 @@
    "id": "c2eae97b-af7f-4d3a-a834-48ed7a400587",
    "metadata": {},
    "source": [
-    "---\n",
+    "\n",
     "Find out what each metric is telling us. Should we trust such high accuracies? Why is accuracy so high compared to the other metrics?\n",
     "\n",
-    "YOUR ANSWER:\n",
-    "\n",
-    "---"
+    "YOUR ANSWER:\n"
    ]
   },
   {


### PR DESCRIPTION
Thank for you for publicly sharing this fantastic content! It's great stuff.

I find it helpful to be able to read the notebook content on the quarto site in addition to on Colab. Maybe others will, as well. To do so, I modified the `_quarto.yml` file and cleaned up a few other files to render the site without error.

You can see the site including notebooks [here](https://jameshwade.quarto.pub/ai4chem).